### PR TITLE
Error if product type is not selected

### DIFF
--- a/Bangazon/Controllers/ProductsController.cs
+++ b/Bangazon/Controllers/ProductsController.cs
@@ -76,10 +76,11 @@ namespace Bangazon.Controllers
             ProductViewModel productModel = new ProductViewModel();
             
             SelectList productTypes = new SelectList(_context.ProductType, "ProductTypeId", "Label");
+            SelectList productTypes2 = ProductTypeDropdown(productTypes);
 
            
 
-            productModel.productTypes = productTypes;
+            productModel.productTypes = productTypes2;
             return View(productModel);
 
 
@@ -107,6 +108,7 @@ namespace Bangazon.Controllers
             }
 
             SelectList ProductTypes = new SelectList(_context.ProductType, "ProductTypeId", "Label");
+
             productModel.productTypes = ProductTypes;
             return View(productModel);
         }
@@ -200,6 +202,26 @@ namespace Bangazon.Controllers
         private bool ProductExists(int id)
         {
             return _context.Product.Any(e => e.ProductId == id);
+        }
+
+        public static SelectList ProductTypeDropdown(SelectList selectList)
+        {
+
+            SelectListItem firstItem = new SelectListItem()
+            {
+               Text = "Select a Product Type"
+            };
+            List<SelectListItem> newList = selectList.ToList();
+            newList.Insert(0, firstItem);      
+
+            var selectedItem = newList.FirstOrDefault(item => item.Selected);
+            var selectedItemValue = String.Empty;
+            if (selectedItem != null)
+            {
+                selectedItemValue = selectedItem.Value;
+            }
+
+            return new SelectList(newList, "Value", "Text", selectedItemValue);
         }
     }
 }

--- a/Bangazon/Controllers/ProductsController.cs
+++ b/Bangazon/Controllers/ProductsController.cs
@@ -74,13 +74,11 @@ namespace Bangazon.Controllers
         {
 
             ProductViewModel productModel = new ProductViewModel();
-            
             SelectList productTypes = new SelectList(_context.ProductType, "ProductTypeId", "Label");
-            SelectList productTypes2 = ProductTypeDropdown(productTypes);
+            // Add a 0 option to the select list
+            SelectList productTypes0 = ProductTypeDropdown(productTypes);
 
-           
-
-            productModel.productTypes = productTypes2;
+            productModel.productTypes = productTypes0;
             return View(productModel);
 
 
@@ -107,9 +105,10 @@ namespace Bangazon.Controllers
                 return RedirectToAction("Details", new { id = productModel.product.ProductId });
             }
 
-            SelectList ProductTypes = new SelectList(_context.ProductType, "ProductTypeId", "Label");
-
-            productModel.productTypes = ProductTypes;
+            SelectList productTypes = new SelectList(_context.ProductType, "ProductTypeId", "Label");
+            // Add a '0' option to the select list
+            SelectList productTypes0 = ProductTypeDropdown(productTypes);
+            productModel.productTypes = productTypes0;
             return View(productModel);
         }
 
@@ -204,6 +203,11 @@ namespace Bangazon.Controllers
             return _context.Product.Any(e => e.ProductId == id);
         }
 
+        /// <summary>
+        /// Adds a '0' option for the select list
+        /// </summary>
+        /// <param name="selectList"></param>
+        /// <returns></returns>
         public static SelectList ProductTypeDropdown(SelectList selectList)
         {
 

--- a/Bangazon/Models/Product.cs
+++ b/Bangazon/Models/Product.cs
@@ -43,7 +43,7 @@ namespace Bangazon.Models
         [Required]
         public ApplicationUser User { get; set; }
 
-        [Required]
+        [Required(ErrorMessage = "Please Select a Product Category")]
         [Display(Name="Product Category")]
         public int ProductTypeId { get; set; }
 

--- a/Bangazon/Views/Products/Create.cshtml
+++ b/Bangazon/Views/Products/Create.cshtml
@@ -58,6 +58,9 @@
             <div class="form-group">
                 <label asp-for="product.ProductTypeId" class="control-label"></label>
                 <select asp-for="product.ProductTypeId" class="form-control" asp-items="@Model.productTypes"></select>
+                <span asp-validation-for="product.ProductTypeId" class="text-danger"></span>
+
+
             </div>
             <div class="form-group">
                 <input type="submit" value="Create" class="btn btn-primary" />

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ From the home page, the user can enter search terms into one of the two search b
 
 ## Selling Products
 
-After logging in, you can click on the link in the nav bar for "sell a product" and a form will be presented with allows you to add the details of the product you wish to add.  Once you hit 'create' you will be redirected to the details view for that product.
+After logging in, you can click on the link in the nav bar for "sell a product" and a form will be presented with allows you to add the details of the product you wish to add.  Once you hit 'create' you will be redirected to the details view for that product.  NOTE:  All the fields except for 'City' and 'Image path' are required and will display an error if they are not completed.
 
 
 


### PR DESCRIPTION
# Description
I've included an error message in a required field to throw an error if a product type is not selected


## Related Ticket(s)
10 -- https://trello.com/c/FFMVTk10/10-10-users-can-select-a-product-category-when-selling-a-product

## Steps to Test
-- Save, add and commit on your branch before checking out to sw-producttype-select
-- Start the app, log in and click on 'sell a product'
-- add all the information about the product but do not select a product type. It should show an error message below the dropdown box.
-- select the product type and create a product, it should post as normal.

# Checklist:
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new errors

