### PR TITLE
View all product categories (quantity and list of Products)

### DIFF
--- a/Bangazon/Bangazon.csproj
+++ b/Bangazon/Bangazon.csproj
@@ -13,4 +13,8 @@
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.2.3" />
   </ItemGroup>
 
+  <ItemGroup>
+    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.1.0-preview1-final" />
+  </ItemGroup>
+
 </Project>

--- a/Bangazon/Controllers/ProductTypesController.cs
+++ b/Bangazon/Controllers/ProductTypesController.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.EntityFrameworkCore;
+using Bangazon.Data;
+using Bangazon.Models;
+
+namespace Bangazon.Controllers
+{
+    public class ProductTypesController : Controller
+    {
+        private readonly ApplicationDbContext _context;
+
+        public ProductTypesController(ApplicationDbContext context)
+        {
+            _context = context;
+        }
+
+        // GET: ProductTypes
+        public async Task<IActionResult> Index()
+        {
+            return View(await _context.ProductType.ToListAsync());
+        }
+
+        // GET: ProductTypes/Details/5
+        public async Task<IActionResult> Details(int? id)
+        {
+            if (id == null)
+            {
+                return NotFound();
+            }
+
+            var productType = await _context.ProductType
+                .FirstOrDefaultAsync(m => m.ProductTypeId == id);
+            if (productType == null)
+            {
+                return NotFound();
+            }
+
+            return View(productType);
+        }
+
+        // GET: ProductTypes/Create
+        public IActionResult Create()
+        {
+            return View();
+        }
+
+   
+
+       
+        
+        private bool ProductTypeExists(int id)
+        {
+            return _context.ProductType.Any(e => e.ProductTypeId == id);
+        }
+    }
+}

--- a/Bangazon/Controllers/ProductTypesController.cs
+++ b/Bangazon/Controllers/ProductTypesController.cs
@@ -22,7 +22,18 @@ namespace Bangazon.Controllers
         // GET: ProductTypes
         public async Task<IActionResult> Index()
         {
-            return View(await _context.ProductType.ToListAsync());
+            var model = await _context.ProductType.Include(pt => pt.Products).ToListAsync();
+            
+
+            //Count the number of products in each category but take only the top three products for each
+            foreach (ProductType productType in model)
+                {
+                productType.Quantity = productType.Products.Count();
+                ICollection<Product> updatedProductList = productType.Products.Take(3).ToList();
+                productType.Products = updatedProductList;
+            }
+
+            return View(model);
         }
 
         // GET: ProductTypes/Details/5

--- a/Bangazon/Models/Product.cs
+++ b/Bangazon/Models/Product.cs
@@ -14,6 +14,8 @@ namespace Bangazon.Models
         [Required]
         [DataType(DataType.Date)]
         [DatabaseGenerated(DatabaseGeneratedOption.Computed)]
+        [Display(Name = "Date Created")]
+
         public DateTime DateCreated {get;set;}
 
         [Required]
@@ -35,7 +37,7 @@ namespace Bangazon.Models
         public string UserId {get; set;}
 
         public string City {get; set;}
-
+        [Display(Name = "Image")]
         public string ImagePath {get; set;}
 
         public bool Active { get; set; }
@@ -46,6 +48,7 @@ namespace Bangazon.Models
         [Required(ErrorMessage = "Please Select a Product Category")]
         [Display(Name="Product Category")]
         public int ProductTypeId { get; set; }
+        [Display(Name = "Product Category")]
 
         public ProductType ProductType { get; set; }
 

--- a/Bangazon/Views/ProductTypes/Details.cshtml
+++ b/Bangazon/Views/ProductTypes/Details.cshtml
@@ -1,0 +1,23 @@
+﻿@model Bangazon.Models.ProductType
+
+@{
+    ViewData["Title"] = "Details";
+}
+
+<h1>Details</h1>
+
+<div>
+    <h4>ProductType</h4>
+    <hr />
+    <dl class="row">
+        <dt class = "col-sm-2">
+            @Html.DisplayNameFor(model => model.Label)
+        </dt>
+        <dd class = "col-sm-10">
+            @Html.DisplayFor(model => model.Label)
+        </dd>
+    </dl>
+</div>
+<div>
+       <a asp-action="Index">Back to List</a>
+</div>

--- a/Bangazon/Views/ProductTypes/Index.cshtml
+++ b/Bangazon/Views/ProductTypes/Index.cshtml
@@ -21,12 +21,23 @@
 @foreach (var item in Model) {
         <tr>
             <td>
-                @Html.DisplayFor(modelItem => item.Label)
+                @Html.DisplayFor(modelItem => item.Label) (@Html.DisplayFor(modelItem => item.Quantity))
+                @foreach (var product in item.Products)
+                {
+                <ul>
+                    @Html.ActionLink(product.Title, "Details", "Products", new { Id = product.ProductId }, null)
+                </ul>
+
+
+                }
             </td>
             <td>
-                
-                <a asp-action="Details" asp-route-id="@item.ProductTypeId">Details</a> 
                
+            </td>
+            <td>
+
+               
+
             </td>
         </tr>
 }

--- a/Bangazon/Views/ProductTypes/Index.cshtml
+++ b/Bangazon/Views/ProductTypes/Index.cshtml
@@ -1,0 +1,34 @@
+﻿@model IEnumerable<Bangazon.Models.ProductType>
+
+@{
+    ViewData["Title"] = "Index";
+}
+
+<h1>Product Types</h1>
+
+
+
+<table class="table">
+    <thead>
+        <tr>
+            <th>
+                @Html.DisplayNameFor(model => model.Label)
+            </th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+@foreach (var item in Model) {
+        <tr>
+            <td>
+                @Html.DisplayFor(modelItem => item.Label)
+            </td>
+            <td>
+                
+                <a asp-action="Details" asp-route-id="@item.ProductTypeId">Details</a> 
+               
+            </td>
+        </tr>
+}
+    </tbody>
+</table>

--- a/Bangazon/Views/Shared/_Layout.cshtml
+++ b/Bangazon/Views/Shared/_Layout.cshtml
@@ -57,7 +57,7 @@
                             <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Index">Home</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Index">Product Types</a>
+                            <a class="nav-link text-dark" asp-area="" asp-controller="ProductTypes" asp-action="Index">Product Categories</a>
                         </li>
                         @if (SignInManager.IsSignedIn(User))
                         {

--- a/Bangazon/Views/Shared/_Layout.cshtml
+++ b/Bangazon/Views/Shared/_Layout.cshtml
@@ -57,7 +57,7 @@
                             <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Index">Home</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link text-dark" asp-area="" asp-controller="ProductTypes" asp-action="Index">Product Categories</a>
+                            <a class="nav-link text-dark" asp-area="" asp-controller="ProductTypes" asp-action="Index">Product Types</a>
                         </li>
                         @if (SignInManager.IsSignedIn(User))
                         {

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 This version of Bangazon implements the Identity framework, and extends the base User object with the `ApplicationUser` model.
 It shows how to remove a model's property from the automatic model binding in a controller method by using `ModelState.Remove()`.
 
+## Product Types
+Clicking on the list of product types, the user can see each category of product type and the total quantity of products in that category listed next to the name.  Below the category name, will be the top three products in that category.  The name of the product will be a hyperlink that can take you to the details view of that product.
+
 ## Viewing Products
 From the home page, the user can enter search terms into one of the two search boxes.  They can either search for product by name, or by location.  Entering a search term will bring them to the index page of the products, with a list matching their search term.  Note, at this point the user may not search for product name and location simultaneously.
 


### PR DESCRIPTION
# Description
The link to product types in the nav bar will now take the user to a listing of all product categories.  Next to the name of the category will be a quantity (number of products in the category) and below will be the top 3 products in that category.


## Related Ticket(s)
11-https://trello.com/c/0qc3441u/11-11-users-can-view-all-product-categories


## Steps to Test
--Save, add and commit on your own branch before checking out to sw-view-all-product-categories.
--Run the app, and log in.  Navigate to 'product types'
--You should see a list of all the prodcut categories (the database was seeded with 10).  Next to the name of each category you should see a number in parenthesis indicating how many products are in that category.
--Below the name of the category will be a list of three(or less) products.  The names of the products are hyperlinks that will take you to the details view of that product.
--Add a product to a category that does not currently have any products (using the 'sell a product' affordance in the NAV).  You can then view the list of product types.  
--The quantity should have increased and you should see the item on the list.  
--Adding an item to a category that already has three or more products will increase the quantity, but it will not show up on the list (it only takes the first three).

# Checklist:
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new errors

